### PR TITLE
training 2: add a new poller and alert.

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -331,6 +331,7 @@ function baseJobFactory(
             data.password = encryption.encrypt(data.password);
         }
 
+        console.log("============base-job.js: pubish data to AMQP");
         return taskProtocol.publishIpmiCommandResult(uuid, command, data);
     };
 

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -77,6 +77,10 @@ function ipmiJobFactory(
                 self.createCallback('chassis', self.collectIpmiChassis.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'driveHealth',
                 self.createCallback('driveHealth', self.collectIpmiDriveHealth.bind(self)));
+            console.log("================power is subcribing....");
+            self._subscribeRunIpmiCommand(self.routingKey, 'power',
+                self.createCallback('power', self.collectIpmiPowerStatus.bind(self)));
+ 
         })
         .catch(function(err) {
             logger.error("Failed to initialize job", { error:err });
@@ -92,7 +96,7 @@ function ipmiJobFactory(
     IpmiJob.prototype.concurrentRequests = function(host, type) {
         assert.string(host);
         assert.string(type);
-
+       
         if (!_.has(this.concurrent, host)) {
             this.concurrent[host] = {
                 sdr: 0,
@@ -100,7 +104,9 @@ function ipmiJobFactory(
                 sel: 0,
                 chassis: 0,
                 driveHealth: 0,
+                power: 0,
                 selEntries: 0
+               //=============================
             };
         }
         if (this.concurrent[host][type] > 0) {
@@ -115,6 +121,7 @@ function ipmiJobFactory(
      */
     IpmiJob.prototype.addConcurrentRequest = function(host, type) {
         assert.object(this.concurrent[host]);
+        console.log("=========Here happen error once.");
         assert.number(this.concurrent[host][type]);
         this.concurrent[host][type] += 1;
     };
@@ -137,6 +144,7 @@ function ipmiJobFactory(
             if (self.concurrentRequests(data.host, cmd)) {
                 return;
             }
+            console.log("======== createCallback init the data.host");
             self.addConcurrentRequest(data.host, cmd);
             return ipmiCallBack(data)
             .then(function(result) {
@@ -144,6 +152,8 @@ function ipmiJobFactory(
                 if(data.password) {
                     delete data.password;
                 }
+                //==============base-job.js========
+                console.log("======== will publish ipmi command result into AMQP.");
                 return self._publishIpmiCommandResult(self.routingKey, cmd, data);
             }).then(function() {
                 return waterline.workitems.findOne({ id: data.workItemId });
@@ -452,7 +462,7 @@ function ipmiJobFactory(
         });
     };
 
-    /**
+     /**
      * Collect drive health status data from IPMI
      * @memberOf IpmiJob
      *
@@ -462,6 +472,21 @@ function ipmiJobFactory(
         return ipmitool.driveHealthStatus(data.host, data.user, data.password)
         .then(function (status) {
             return parser.parseDriveHealthData(status);
+        });
+    };
+
+    /**
+     * Collect power status data from IPMI
+     * @memberOf IpmiJob
+     *
+     * @param data
+     */
+    IpmiJob.prototype.collectIpmiPowerStatus = function(data) {
+        console.log("======== enter ipmitool.powerStatus()");
+        return ipmitool.powerStatus(data.host, data.user, data.password)
+        .then(function (status) {
+            console.log("========ipmitool.powerStatus data:" + status);
+            return parser.parsePowerStatusData(status);
         });
     };
 

--- a/lib/jobs/ipmi-power-alert-job.js
+++ b/lib/jobs/ipmi-power-alert-job.js
@@ -1,0 +1,144 @@
+//  lib/task-data/base-tasks/ipmi-power-poller-alert.js
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = pollerMessageCacheJobFactory;
+di.annotate(pollerMessageCacheJobFactory, new di.Provide('Job.Poller.Alert.Ipmi.Power'));
+di.annotate(pollerMessageCacheJobFactory, new di.Inject(
+    'Job.Base',
+    'Services.Configuration',
+    'Logger',
+    'Util',
+    'Assert',
+    'Errors',
+    'Promise',
+    '_'
+));
+function pollerMessageCacheJobFactory(
+    BaseJob,
+    configuration,
+    Logger,
+    util,
+    assert,
+    Errors,
+    Promise,
+    _
+) {
+    var logger = Logger.initialize(pollerMessageCacheJobFactory);
+
+    /**
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function PollerMessageCacheJob(options, context, taskId) {
+        PollerMessageCacheJob.super_.call(this, logger, options, context, taskId);
+
+        this.routingKey = context.graphId;
+        assert.uuid(this.routingKey) ;
+        this.cachedPowerState = {};
+    }
+    util.inherits(PollerMessageCacheJob, BaseJob);
+
+    /**
+     * @memberOf PollerMessageCacheJob
+     */
+    PollerMessageCacheJob.prototype.cacheSet = function(id, data) {
+        if (!data) {
+            return;
+        }
+        console.log("++++++++++++++ data" + JSON.stringify(data))
+        var cache = this.cache[id];
+        if (!cache) {
+            cache = [];
+            this.cache[id] = cache;
+        }
+        data.timestamp = Date();
+        cache.push(data);
+        if (cache.length > this.maxCacheSize) {
+            cache.shift();
+        }
+    };
+
+    /**
+     * @memberOf PollerMessageCacheJob
+     */
+    PollerMessageCacheJob.prototype.cacheGet = function(id) {
+        return this.cache[id];
+    };
+
+    /**
+     * @memberOf PollerMessageCacheJob
+     */
+    PollerMessageCacheJob.prototype.cacheHas = function(id) {
+        return _.has(this.cache, id);
+    };
+
+    /**
+     * @memberOf PollerMessageCacheJob
+     */
+    PollerMessageCacheJob.prototype._run = function run() {
+        // NOTE: this job will run indefinitely absent user intervention
+        var self = this;
+        console.log("++++++++++ go into power alert.")
+        _.forEach(['power'], 
+            function(command) {
+            self._subscribeIpmiCommandResult(
+                self.routingKey,
+                command,
+                self.createSetIpmiCommandResultCallback(command)
+            );
+        });
+    
+    };
+
+    /**
+     * @memberOf PollerMessageCacheJob
+     */
+    PollerMessageCacheJob.prototype.createSetIpmiCommandResultCallback = function(command) {
+        var self = this;
+        return function(data) {
+            console.log("+++++++++++++++ get data from MQ, raw data:" + JSON.stringify(data));
+            self.powerStateAlerter(data.power.status, data);
+        };
+    };
+    
+   /**
+     * Compare current and last power states and publish alert on a state change
+     * @memberOf IpmiJob
+     * @param status
+     * @param data
+     */
+     PollerMessageCacheJob.prototype.powerStateAlerter = Promise.method(function(status, data) {
+        console.log("+++++++++++++++ alert raw data's status:" + JSON.stringify(status));
+        console.log("+++++++++++++++ alert raw data:" + JSON.stringify(data));
+        var self = this;
+        var tmp = {};
+        tmp.type = 'polleralert';
+        tmp.action = 'chassispower.updated';
+        tmp.typeId = data.workItemId;
+        tmp.nodeId = data.node;
+        tmp.severity = "information";
+        tmp.data = {
+            states: {
+                last: self.cachedPowerState[data.workItemId],
+                current: status
+            }
+        };
+        console.log("++++++++++++++ tmp.data.states:" + JSON.stringify(tmp.data.states));
+        if(self.cachedPowerState[data.workItemId] !== status) {
+            console.log("++++++++++ triger an alert.....");
+            console.log("++++++++++ alert content:" + JSON.stringify(tmp));
+            self._publishPollerAlert(tmp);
+            self.cachedPowerState[data.workItemId] = status;
+        }
+        return status;
+    });
+
+    return PollerMessageCacheJob;
+}
+

--- a/lib/jobs/message-cache-job.js
+++ b/lib/jobs/message-cache-job.js
@@ -90,8 +90,11 @@ function pollerMessageCacheJobFactory(
                    'sel', 
                    'selEntries', 
                    'chassis', 
+                   'power', 
                    'driveHealth'], 
             function(command) {
+            console.log("======== command is:" + command);
+            console.log("======== message cache job subsrcible the ipmi data through AMQP.");
             self._subscribeIpmiCommandResult(
                 self.routingKey,
                 command,

--- a/lib/task-data/base-tasks/ipmi-power-poller-alert.js
+++ b/lib/task-data/base-tasks/ipmi-power-poller-alert.js
@@ -1,0 +1,12 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Ipmi Power Poller Alerts',
+    injectableName: 'Task.Base.Poller.Alert.Ipmi.Power',
+    runJob: 'Job.Poller.Alert.Ipmi.Power',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -300,6 +300,12 @@ function parseSensorsDataFactory(assert, _) {
         }
         return statusArr;
     }
+   
+    function parsePowerStatusData(powerStatusData) {
+         let powerStatus = powerStatusData.startsWith("Chassis Power is on") ? "ON" : "OFF"; 
+         console.log("======== power status raw:" + JSON.stringify(powerStatusData) + ",=== simple:" + powerStatus);
+         return {"status": powerStatus};
+    }
 
     return {
         parseSelInformationData: parseSelInformationData,
@@ -307,6 +313,8 @@ function parseSensorsDataFactory(assert, _) {
         parseSelDataEntries: parseSelDataEntries,
         parseSdrData: parseSdrData,
         parseChassisData: parseChassisData,
-        parseDriveHealthData: parseDriveHealthData
+        parseDriveHealthData: parseDriveHealthData,
+        //============
+        parsePowerStatusData: parsePowerStatusData
     };
 }


### PR DESCRIPTION
# 1 Backgroud: Poller
## 2.1 Target
understand
- RackHD poller mechanism
- AMQP pub/sub mechnism
- obm setting and IPMI basic knowledge


## 2.2 Exercise
1. Add a new IPMI poller “powerStatus”
1. (optional) send out event when the status changes

## 2.3 Recommended steps:
### 1. add obm setting to node
- `curl localhost:8080/api/2.0/nodes/598adbb4a1ea99de4028182a/obm | jq '.'`
- `curl localhost:8080/api/current/nodes/598adbb4a1ea99de4028182a/catalogs/bmc | jq '.' | grep "IP Address"`
- `curl -k -X PUT -H 'Content-Type: application/json' -d '{ "nodeId": "598adbb4a1ea99de4028182a ", "service": "ipmi-obm-service", "config": { "user": "admin", "password": "admin", "host": "172.31.128.4" } }' localhost:8080/api/2.0/obms`
- `curl -k -X PUT -H 'Content-Type: application/json' -d '{ "nodeId": "<nodeId>", "service": "ipmi-obm-service", "config": { "user": "admin", "password": "admin", "host": "<BMC-IP>" } }' localhost:8080/api/2.0/obms`

### 2 .add the powerStatus poller.
- By either using API (http://rackhd.readthedocs.io/en/latest/rackhd/pollers.html) 
- or adding an option in discovery tasks (https://github.com/RackHD/on-taskgraph/blob/master/lib/graphs/discovery-sku-graph.js#L154) and rediscovery the node
 
### 3. add logic to send out ipmi command and parse it.
Related jobs: ipmi-job.js, message-cache-job.js

### 4. The IPMI command that will be used is:
onrack@lyne-env:~$ `ipmitool -I lanplus -U admin -P admin -H 172.31.128.19 chassis power status`
> Chassis Power is off

The poller data will be:
```json
[
    {
        "host": "172.31.128.19",
        "node": "59882145b6d821c25ba8c604",
        "powerStatus": {
            "status": “OFF”
        },
        "timestamp": "Tue Aug 08 2017 06:14:06 GMT+0000 (UTC)",
        "user": "admin"
    }
]
```
### 5.Verify the poller data can change with the power status.
Send out IPMI command to change power status:
`ipmitool -I lanplus -U admin -P admin -H 172.31.128.19 chassis power on`
and verify that the poller data changes accordingly.

> (optional) Write a job to send out AMQP message when the power status changes.

# 2  Related PR
see related PR : [on-taskgraph:1](https://github.com/HQebupt/on-taskgraph/pull/2)

# 3 Result
## 3.1 Useful command:
- get latest pooler data: `curl 127.0.0.1:8080/api/2.0/pollers/598ade38a1ea99de4028182c/data | jq '.'`
- update poller: `curl -X PATCH -H 'Content-Type: application/json' -d '{"pollInterval":15000}' 127.0.0.1:8080/api/2.0/pollers/598ade38a1ea99de4028182c`
- ipmi command : `ipmitool -I lanplus -U admin -P admin -H 172.31.128.4 chassis power status`

## 3.2 get the power poller data
```
[
{
    "timestamp": "Thu Aug 10 2017 19:59:40 GMT-0600 (MDT)",
    "power": {
      "status": "OFF"
    },
    "node": "598adbb4a1ea99de4028182a",
    "host": "172.31.128.4",
    "user": "admin"
  },
  {
    "timestamp": "Thu Aug 10 2017 19:59:55 GMT-0600 (MDT)",
    "power": {
      "status": "OFF"
    },
    "node": "598adbb4a1ea99de4028182a",
    "host": "172.31.128.4",
    "user": "admin"
  },
  {
    "timestamp": "Thu Aug 10 2017 20:00:10 GMT-0600 (MDT)",
    "power": {
      "status": "ON"
    },
    "node": "598adbb4a1ea99de4028182a",
    "host": "172.31.128.4",
    "user": "admin"
  }
]
```

## 3.3 get the alert event.
```json
{
  "data": {
    "states": {
      "current": "ON",
      "last": "OFF"
    }
  },
  "severity": "information",
  "nodeId": "598adbb4a1ea99de4028182a",
  "typeId": "598ade38a1ea99de4028182c",
  "action": "chassispower.updated",
  "type": "polleralert"
}

```

# 4 Log
```
+++++++++++++++ get data from MQ, raw data:{"user":"admin","host":"172.31.128.4","node":"598adbb4a1ea99de4028182a","workItemId":"598ade38a1ea99de4028182c","power":{"status":"OFF"}}
+++++++++++++++ alert raw data's status:"OFF"
+++++++++++++++ alert raw data:{"user":"admin","host":"172.31.128.4","node":"598adbb4a1ea99de4028182a","workItemId":"598ade38a1ea99de4028182c","power":{"status":"OFF"}}
++++++++++++++ tmp.data.states:{"last":"OFF","current":"OFF"}


======== power status raw:"Chassis Power is on\n",=== simple:ON
======== will publish ipmi command result into AMQP.
============base-job.js: pubish data to AMQP
========on-core taskProtocol, put into AMQP.
+++++++++++++++ get data from MQ, raw data:{"user":"admin","host":"172.31.128.4","node":"598adbb4a1ea99de4028182a","workItemId":"598ade38a1ea99de4028182c","power":{"status":"ON"}}
+++++++++++++++ alert raw data's status:"ON"
+++++++++++++++ alert raw data:{"user":"admin","host":"172.31.128.4","node":"598adbb4a1ea99de4028182a","workItemId":"598ade38a1ea99de4028182c","power":{"status":"ON"}}
++++++++++++++ tmp.data.states:{"last":"OFF","current":"ON"}
++++++++++ triger an alert.....
++++++++++ alert content:{"type":"polleralert","action":"chassispower.updated","typeId":"598ade38a1ea99de4028182c","nodeId":"598adbb4a1ea99de4028182a","severity":"information","data":{"states":{"last":"OFF","current":"ON"}}}

```
